### PR TITLE
Fix JSON path casing and minor syntax issue

### DIFF
--- a/src/Controller/ApiCurr.php
+++ b/src/Controller/ApiCurr.php
@@ -32,7 +32,7 @@ class ApiCurr extends AbstractController
             $Provider = $currService->provider(new $className());
 
 
-                $response = file_get_contents($Provider->getJsonUrl());;
+                $response = file_get_contents($Provider->getJsonUrl());
                 $response = json_decode($response, true);
 
 

--- a/src/Provider/Provider3.php
+++ b/src/Provider/Provider3.php
@@ -10,7 +10,8 @@ class Provider3 implements ProviderInterface{
     public function exchange()
     {
         $provider = new ProviderService();
-        $provider->setJsonUrl(__DIR__."/../../src/provider3.json");
+        // use the correct case for the local JSON file
+        $provider->setJsonUrl(__DIR__."/../../src/Provider3.json");
         $provider->setAmount("TLKarsiligi");
         $provider->setSymbol("kurAdi");
         $provider->setDolar("Usd");


### PR DESCRIPTION
## Summary
- correct the case of the Provider3 JSON file path
- remove an extra semicolon when fetching provider data

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6849365010e08321ade63b69a8dcbc76